### PR TITLE
Support for subfile, and reduction of errors thrown by grammar checkers

### DIFF
--- a/detex.1l
+++ b/detex.1l
@@ -71,6 +71,12 @@ and magic characters like `{' when recognizing things like
 .I LaTeX
 environments.
 .PP
+The
+.B \-r
+option tries to naively replace $..$, $$..$$, \(..\) and \[..\]
+with nouns and verbs (in particular, "noun" and "verbs")
+in a way that keeps sentences readable.
+.PP
 If the
 .B \-w
 flag is given, the output is a word list, one `word' (string of two or more

--- a/detex.h
+++ b/detex.h
@@ -80,5 +80,6 @@
 #define	CHSPACEOPT	's'
 #define	CHTEXOPT	't'
 #define	CHWORDOPT	'w'
+#define CHREPLACE   'r'
 
 #define	my_ERROR	-1

--- a/detex.l
+++ b/detex.l
@@ -180,7 +180,7 @@ Z	\*?
 VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subset|\\sim|\neq
 
 %Start Define Display IncludeOnly Input Math Normal Control
-%Start LaBegin LaDisplay LaEnd LaEnv LaFormula LaInclude
+%Start LaBegin LaDisplay LaEnd LaEnv LaFormula LaInclude LaSubfile
 %Start LaMacro LaOptArg LaMacro2 LaOptArg2 LaVerbatim 
 %start LaBreak LaPicture
 
@@ -385,6 +385,13 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subset|\\sim|\neq
 						}
 <IncludeOnly>"\n"+				NEWLINE;
 <IncludeOnly>.					;
+
+<Normal>"\\subfile"	/* process files */	{LaBEGIN LaSubfile; IGNORE;}
+<LaSubfile>[^{ \t\n}]+				{   IncludeFile(yytext);
+						    BEGIN Normal;
+						}
+<LaSubfile>"\n"+					NEWLINE;
+<LaSubfile>.					;
 
 <Normal>"\\input"				{BEGIN Input; IGNORE;}
 <Input>[^{ \t\n}]+				{   InputFile(yytext);

--- a/detex.l
+++ b/detex.l
@@ -90,6 +90,8 @@
 
 #define	LaBEGIN		if (fLatex) BEGIN
 #define	IGNORE		if (fSpace && !fWord) putchar(' ')
+#define NOUN		if (fSpace && !fWord && !fReplace) putchar(' '); else {if (fReplace) printf("noun");}
+#define VERBNOUN		if (fReplace) printf(" verbs noun"); /* puts a verb and a noun to make grammar checking work */
 #define	SPACE		if (!fWord) putchar(' ')
 #define	NEWLINE		if (!fWord) putchar('\n')
 #define	LATEX		fLatex=!fForcetex
@@ -148,6 +150,7 @@ int	fCite = 0;			/* flag to echo \cite and \ref args */
 int	fSpace = 0;			/* flag to replace \cs with space */
 int	fForcetex = 0;			/* flag to inhibit latex mode */
 int fShowPictures = 0;  /* flag to show picture names */
+int fReplace = 0;  /* flag to replace envirnments with "noun" */
 
 int currBracesLevel = 0;
 int footnoteLevel = -100;
@@ -174,6 +177,7 @@ VU	{U}|ex
 VD	{S}(({N}{S}{VU})|(\\{W})){S}
 VG	{VD}(plus{VD})?(minus{VD})?
 Z	\*?
+VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\mapsto|\\subset|\\sim
 
 %Start Define Display IncludeOnly Input Math Normal Control
 %Start LaBegin LaDisplay LaEnd LaEnv LaFormula LaInclude
@@ -341,25 +345,29 @@ Z	\*?
 <Define>"\n"					NEWLINE;
 <Define>.					;
 
-<Normal>"\\("		/* formula mode */	{LaBEGIN LaFormula; IGNORE;}
+<Normal>"\\("		/* formula mode */	{LaBEGIN LaFormula; NOUN;}
 <LaFormula>"\\)"				BEGIN Normal;
 <LaFormula>"\n"					NEWLINE;
+<LaFormula>{VERBSYMBOL}			VERBNOUN;
 <LaFormula>.					;
 
-<Normal>"\\["		/* display mode */	{LaBEGIN LaDisplay; IGNORE;}
+<Normal>"\\["		/* display mode */	{LaBEGIN LaDisplay; NOUN;}
 <LaDisplay>"\\]"				BEGIN Normal;
 <LaDisplay>"\n"					NEWLINE;
+<LaDisplay>{VERBSYMBOL}			VERBNOUN;
 <LaDisplay>.					;
 
-<Normal>"$$"		/* display mode */	{BEGIN Display; IGNORE;}
+<Normal>"$$"		/* display mode */	{BEGIN Display; NOUN;}
 <Display>"$$"					BEGIN Normal;
 <Display>"\n"					NEWLINE;
+<Display>{VERBSYMBOL}			VERBNOUN;
 <Display>.					;
 
-<Normal>"$"		/* math mode */		{BEGIN Math; IGNORE;}
+<Normal>"$"		/* math mode */		{BEGIN Math; NOUN;}
 <Math>"$"					BEGIN Normal;
 <Math>"\n"					NEWLINE;
 <Math>"\\$"					;
+<Math>{VERBSYMBOL}			VERBNOUN;
 <Math>.						;
 
 <Normal>"\\include"	/* process files */	{LaBEGIN LaInclude; IGNORE;}
@@ -546,6 +554,9 @@ main(int cArgs, char *rgsbArgs[])
 			break;
 		    case CHWORDOPT:
 			fWord = 1;
+			break;
+			case CHREPLACE:
+			fReplace = 1;
 			break;
 		    default:
 			sbBadOpt[0] = *pch;
@@ -974,6 +985,7 @@ UsageExit(void)
 -n  do not follow \\input and \\include\n  \
 -s  replace control sequences with space\n  \
 -t  force tex mode\n  \
--w  word only output");
+-w  word only output\n \
+-r  replace math with \"noun\"");
 	exit(0);
 }

--- a/detex.l
+++ b/detex.l
@@ -177,7 +177,7 @@ VU	{U}|ex
 VD	{S}(({N}{S}{VU})|(\\{W})){S}
 VG	{VD}(plus{VD})?(minus{VD})?
 Z	\*?
-VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subset|\\sim|\neq
+VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\\neq|\\mapsto
 
 %Start Define Display IncludeOnly Input Math Normal Control
 %Start LaBegin LaDisplay LaEnd LaEnv LaFormula LaInclude LaSubfile
@@ -989,8 +989,8 @@ UsageExit(void)
 	puts("  -c  echo LaTeX \\cite, \\ref, and \\pageref values\n  \
 -e  <env-list> list of LaTeX environments to ignore\n  \
 -l  force latex mode\n  \
--n  do not follow \\input and \\include\n  \
--r  replace math with \"noun\"\n  \
+-n  do not follow \\input, \\include and \\subfile\n  \
+-r  replace math with \"noun\" and \"noun verbs noun\" to preserve grammar\n  \
 -s  replace control sequences with space\n  \
 -t  force tex mode\n  \
 -w  word only output");

--- a/detex.l
+++ b/detex.l
@@ -177,7 +177,7 @@ VU	{U}|ex
 VD	{S}(({N}{S}{VU})|(\\{W})){S}
 VG	{VD}(plus{VD})?(minus{VD})?
 Z	\*?
-VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\mapsto|\\subset|\\sim
+VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subset|\\sim|\neq
 
 %Start Define Display IncludeOnly Input Math Normal Control
 %Start LaBegin LaDisplay LaEnd LaEnv LaFormula LaInclude

--- a/detex.l
+++ b/detex.l
@@ -977,15 +977,15 @@ ErrorExit(const char *sb1)
 void
 UsageExit(void)
 {
-	(void)printf("\n%s [ -clnstw ] [ -e environment-list ] [ filename[.tex] ... ]\n",
+	(void)printf("\n%s [ -clnrstw ] [ -e environment-list ] [ filename[.tex] ... ]\n",
 		sbProgName);
 	puts("  -c  echo LaTeX \\cite, \\ref, and \\pageref values\n  \
 -e  <env-list> list of LaTeX environments to ignore\n  \
 -l  force latex mode\n  \
 -n  do not follow \\input and \\include\n  \
+-r  replace math with \"noun\"\n  \
 -s  replace control sequences with space\n  \
 -t  force tex mode\n  \
--w  word only output\n \
--r  replace math with \"noun\"");
+-w  word only output");
 	exit(0);
 }

--- a/test.pl
+++ b/test.pl
@@ -5,6 +5,8 @@ assert_produces_correct_output('in.tex', 'correct.txt', '-l');
 assert_produces_correct_output('noinclude.tex', 'noinclude-correct.txt', '-n');
 assert_produces_correct_output('words.tex', 'words-correct.txt', '-w');
 assert_produces_correct_output('words.tex', 'words-correct.txt', '-w -l');
+assert_produces_correct_output('nouns.tex', 'nouns-correct.txt', '-r');
+
 run_for_wrong_input("non-existent-file");
 run_for_wrong_input("non-existent-file.tex");
 run_for_wrong_input("non-existent-file.txt");

--- a/test/nouns-correct.txt
+++ b/test/nouns-correct.txt
@@ -1,0 +1,5 @@
+Facts: noun is a number, noun verbs noun, noun verbs noun, noun verbs noun verbs noun.
+
+Also noun verbs noun verbs noun verbs noun and noun verbs noun verbs noun.
+
+So noun verbs noun verbs noun. Hence noun verbs noun.

--- a/test/nouns.tex
+++ b/test/nouns.tex
@@ -1,0 +1,8 @@
+\documentclass[draft]{book}
+\begin{document}
+Facts: $0$ is a number, $0 < 1$, $1 \leq 2$, $2 \geq 1 > 0$.
+
+Also $0 \in [0,1] \subset [0,2] \subseteq [0,2]$ and $0 = 0 \leq 1$.
+
+So $[0,2] \supseteq [0,2] \supset [0,1]$. Hence $0 \mapsto 0$.
+\end{document}


### PR DESCRIPTION
I have tried to preserve sentence structure of sentences with math in them a bit. The current solution is not very good, but it reduces errors thrown by Grammarly a lot. I replaced math environments by the word "noun", and verb symbols (such as =, <, \in) by "verbs noun". Examples:

Then $P$ is non-degenerate. -> Then noun is non-degenerate.
So $x \in P$. -> So noun verbs noun.