### PR TITLE
Stop generating additional spaces after commands

### DIFF
--- a/detex.l
+++ b/detex.l
@@ -442,7 +442,7 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 								putchar(')');
 								footnoteLevel = -100;
 							}
-							SPACE;}
+							}
 <Normal>{W}[']*{W}				{   if (fWord)
 							(void)printf("%s\n", yytext);
 						    else

--- a/test/correct.txt
+++ b/test/correct.txt
@@ -8,51 +8,51 @@
 
 
 
-First 
+First
 
 Between
 
-Something 
-Begin of text. Bold , teletype , small caps  etc.
-Emphasis  verb1 - or - verb2
+Something
+Begin of text. Bold, teletype, small caps etc.
+Emphasis verb1 - or - verb2
 
 Now label and reference and
 another indexing . Also don't show
 cites without, or with space.
 
-Footnotes have to (be shown)  also with (numbers
+Footnotes have to (be shown) also with (numbers
 or
-complex  - content) .
+complex - content).
 
 Now hyphenation and "various" "styles" "of" "quotes" 'more'.
 
-Special characters: test/ slash
+Special characters: test/slash
 
 This is minipage.
 
 
-			This is figure. 
-	 
+			This is figure.
+	
 
 
- 
-This is table. 
 
- 
+This is table.
 
- 
 
- 
+
+
+
+
 Hey, this is sloppypar!
 
 Paragraph
 markup
- commands
+commands
 
 Later on
 
 
 Text to include.
- 
+
 
 where

--- a/test/noinclude-correct.txt
+++ b/test/noinclude-correct.txt
@@ -1,3 +1,3 @@
 Only text from this file will be processed
- 
- 
+
+


### PR DESCRIPTION
detex generates additional spaces.
E.g.
`\emph{Test}Foo` becomes `Test Foo`

The reason was an additional inserted space after each closing brace "}".
This patch removes that behavior.