### PR TITLE
after a control sequence ignore only the first newline

### DIFF
--- a/detex.l
+++ b/detex.l
@@ -419,7 +419,7 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 
 <Control>\\[a-zA-Z@]+				IGNORE;
 <Control>[a-zA-Z@0-9]*[-'=`][^ \t\n{]*		IGNORE;
-<Control>"\n"+					{BEGIN Normal; /*NEWLINE;*/}
+<Control>"\n"					{BEGIN Normal; /*NEWLINE;*/}
 <Control>[ \t]*[{]+				{++currBracesLevel;BEGIN Normal; IGNORE;}
 <Control>[ \t]*				{BEGIN Normal; IGNORE;}
 <Control>.					{yyless(0);BEGIN Normal;}

--- a/test/correct.txt
+++ b/test/correct.txt
@@ -56,3 +56,4 @@ Text to include.
 
 
 where
+


### PR DESCRIPTION
This turned out much simpler than I imaged when I opened Issue #42: after a control sequence, only the first newline should be ignored, not all following ones.

Actually, this is only a partial fix. According to Tex by Topics, when a control sequence ends (which happens when the next  character is not a letter) the parser goes into state S (skipping spaces) where the next newline makes it enter state N (new line). If this other line contains only spaces, a \par is inserted.

Even with this commit, that \par is still not inserted. That would require the detex grammar to have states for N and S. At least, a newline is output instead of joining the lines with no spaces in between.