### PR TITLE
newlines are like spaces in math inline mode

### DIFF
--- a/detex.l
+++ b/detex.l
@@ -365,7 +365,7 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 
 <Normal>"$"		/* math mode */		{BEGIN Math; NOUN;}
 <Math>"$"					BEGIN Normal;
-<Math>"\n"					NEWLINE;
+<Math>"\n"					;
 <Math>"\\$"					;
 <Math>{VERBSYMBOL}			VERBNOUN;
 <Math>.						;

--- a/test/correct.txt
+++ b/test/correct.txt
@@ -59,6 +59,8 @@ Line ending with macro
 
 should not eat an empty newline
 
+An inline math equation like  should not produce an empty line
+
 Text to include.
 
 

--- a/test/in.tex
+++ b/test/in.tex
@@ -99,6 +99,10 @@ Line ending with macro\macro{}
 
 should not eat an empty newline
 
+An inline math equation like $a +
+b +
+c$ should not produce an empty line
+
 \input{part}
 \newcounter{equation}
 


### PR DESCRIPTION
TeX treats newlines as spaces when in inline math, except that empty
lines cause errors. In other words, a correct latex file never
contains two consecutive newlines, and a single newline is considered
like a space in inline math.

Without this commit, two newlines in an line math formula create an
empty line. These are treated like paragraph endings, and therefore
sentence endings, by LanguageTool.