### PR TITLE
Move man page to section 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,14 +120,14 @@ detex.c: detex.l
 	mv lex.yy.c detex.c
 
 man-page:
-	troff -man detex.1l
+	troff -man detex.1
 
 # If you want detex available as delatex, uncomment the last two lines of
 # this target
 install: all
 	rm -f ${DESTDIR}/detex
 	install -c -m 775 -g staff -s detex ${DESTDIR}
-	install detex.1l /usr/local/share/man/man1
+	install detex.1 /usr/local/share/man/man1
 #	rm -f ${DESTDIR}/delatex
 #	ln ${DESTDIR}/detex ${DESTDIR}/delatex
 

--- a/detex.1
+++ b/detex.1
@@ -1,4 +1,4 @@
-.TH DETEX 1L "12 August 1993" "Purdue University"
+.TH DETEX 1 "12 August 1993" "Purdue University"
 .SH NAME
 detex \- a filter to strip \fITeX\fP commands from a .tex file.
 .SH SYNOPSIS
@@ -109,7 +109,7 @@ The old functionality can be essentially duplicated by using the
 .B \-s
 option.
 .SH SEE ALSO
-tex(1L)
+tex(1)
 .SH DIAGNOSTICS
 Nesting of \\input is allowed but the number of opened files must not
 exceed the system's limit on the number of simultaneously opened files.


### PR DESCRIPTION
Some OSes, like macOS, don't have a 1L man section. Please consider renaming the man page to section 1, supported by all Unices.