### PR TITLE
Add Autotools build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ detex
 detex.c
 detex.o
 *.tar.bz2
+
+Makefile.in
+aclocal.m4
+autom4te.cache
+configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ addons:
     - autoconf
     - automake
     - autoconf-archive
+before_install:
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew update;
+      brew upgrade automake;
+      brew upgrade autoconf;
+      brew upgrade autoconf-archive;
+    fi
 before_script:
   - lex --version
   - flex --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ before_script:
 script:
   - make -f Makefile.sample all test.pl
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ./test.pl; else ./test.pl --valgrind; fi
-  - autoreconf-2.69 --install
+  - autoreconf --install
   - ./configure
   - make distcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ addons:
     packages:
     - flex
     - valgrind
+    - autoconf
+    - automake
+    - autoconf-archive
 before_script:
   - lex --version
   - flex --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,8 @@ before_script:
   - flex --version
   - if [ "$TRAVIS_OS_NAME" != "osx" ]; then valgrind --version; fi
 script:
-  - make
+  - make -f Makefile.sample all test.pl
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ./test.pl; else ./test.pl --valgrind; fi
+  - autoreconf --install
+  - ./configure
+  - make distcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ addons:
     - autoconf-archive
 before_install:
   - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew update;
-      brew upgrade automake;
-      brew upgrade autoconf;
-      brew upgrade autoconf-archive;
+      brew upgrade automake || true;
+      brew reinstall autoconf || true;
+      brew install autoconf-archive || true;
     fi
 before_script:
   - lex --version
@@ -26,6 +26,6 @@ before_script:
 script:
   - make -f Makefile.sample all test.pl
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ./test.pl; else ./test.pl --valgrind; fi
-  - autoreconf --install
+  - autoreconf-2.69 --install
   - ./configure
   - make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,9 @@ TEST_EXTENSIONS = .pl
 PL_LOG_COMPILER = $(PERL)
 AM_PL_LOG_FLAGS = -w
 
+PL_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
+	$(top_srcdir)/aux_files/tap-driver.sh
+
 dist_check_DATA = test/correct.txt test/in.tex test/noinclude.tex	\
 	test/noinclude-correct.txt test/nouns.tex			\
 	test/nouns-correct.txt test/part.tex test/unterminated.txt	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,37 @@
+bin_PROGRAMS = detex
+
+detex_SOURCES = detex.h detex.l
+detex_AMCFLAGS = -O
+# detex_AMCPPFLAGS = -DVERSION=\"${VERSION}\"
+
+dist_man_MANS = detex.1
+
+TESTS = test.pl
+TEST_EXTENSIONS = .pl
+PL_LOG_COMPILER = $(PERL)
+AM_PL_LOG_FLAGS = -w
+
+dist_check_DATA = test/correct.txt test/in.tex test/noinclude.tex	\
+	test/noinclude-correct.txt test/nouns.tex			\
+	test/nouns-correct.txt test/part.tex test/unterminated.txt	\
+	test/words.tex test/words-correct.txt
+dist_check_SCRIPTS = test.pl valgrind.sh
+
+EXTRA_DIST = ChangeLog COPYRIGHT INSTALL README README-development.md \
+	CONTRIBUTING Makefile.sample
+
+install-exec-hook:
+	(cd "$(DESTDIR)$(bindir)" && rm -f delatex && $(LN_S) detex$(EXEEXT) delatex)
+
+uninstall-hook:
+	(cd "$(DESTDIR)$(bindir)" && rm -f delatex)
+
+installcheck-local:
+	test -x "$(DESTDIR)$(bindir)/detex$(EXEEXT)"
+	test -x "$(DESTDIR)$(bindir)/delatex"
+
+check-valgrind:
+	./test.pl --valgrind
+
+print: detex.h detex.l
+	lpr -p Makefile detex.h detex.l

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,3 +38,5 @@ check-valgrind:
 
 print: detex.h detex.l
 	lpr -p Makefile detex.h detex.l
+
+ACLOCAL_AMFLAGS = -I m4

--- a/Makefile.sample
+++ b/Makefile.sample
@@ -140,11 +140,16 @@ clean:
 	-rm -f a.out core *.s *.o ERRS errs .,* .emacs_[0-9]*
 	-rm -f ${PROGS} xxx.l lex.yy.c detex.c
 	-rm -f *.tar.bz2
+	-rm -f config.h test.pl
 
 print:	${HDR} ${SRC}
 	${LPR} Makefile ${HDR} ${SRC}
 
-test: all
+test.pl: test.pl.in
+	sed -e 's/@top_srcdir@/./g' test.pl.in >test.pl
+	chmod u+x test.pl
+
+test: all test.pl
 	./test.pl
 
 run: delatex
@@ -158,3 +163,7 @@ package: clean detex.c
 detex.c: detex.h
 detex.c: detex.l
 
+detex.o: config.h
+
+config.h:
+	touch config.h

--- a/README-development.md
+++ b/README-development.md
@@ -16,7 +16,7 @@ After pushing check cross-platform compilation results on commits list on GitHub
 
 1. Create a commit setting version to stable:
   - ChangeLog: change UNRELEASED to current date
-  - Makefile: strip -UNRELEASED from version number
+  - Makefile.sample and configure.ac: strip -UNRELEASED from version number
   - README: remove UNRELEASED
 2. Make sure it works: `make clean test package`
 3. Git-tag this version like "v2.8.5"

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,46 @@
+#                                               -*- Autoconf -*-
+# Process this file with autoconf to produce a configure script.
+
+AC_PREREQ([2.69])
+AC_INIT([opendetex], [2.8.6-UNRELEASED], [BUG-REPORT-ADDRESS])
+AC_CONFIG_SRCDIR([detex.h])
+AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_AUX_DIR([aux_files])
+AC_CONFIG_MACRO_DIR([m4])
+
+AM_INIT_AUTOMAKE([foreign dist-bzip2])
+
+# Checks for programs.
+AC_PROG_CC
+AC_PROG_LEX
+AX_PROG_FLEX([AC_SUBST([FLEX_SCANNER], [1])], [])
+AC_PROG_LN_S
+AC_PROG_INSTALL
+AC_PROG_MAKE_SET
+AC_PATH_PROG([PERL], [perl])
+AX_CFLAGS_WARN_ALL
+
+# Checks for libraries.
+# FIXME: Replace `main' with a function in `-lfl':
+AC_CHECK_LIB([fl], [yylex])
+# also yywrap, yyrestart
+
+# Checks for header files.
+AC_CHECK_HEADERS([fcntl.h stdlib.h string.h strings.h sys/param.h limits.h])
+
+# Checks for typedefs, structures, and compiler characteristics.
+AC_CHECK_HEADER_STDBOOL
+
+# Checks for library functions.
+AC_FUNC_MALLOC
+AC_CHECK_FUNCS([strchr strrchr])
+
+AC_CONFIG_FILES([Makefile test.pl])
+dnl AC_CONFIG_LINKS([correct.txt:test/correct.txt in.tex:test/in.tex
+dnl     noinclude.tex:test/noinclude.tex
+dnl     noinclude-correct.txt:test/noinclude-corrext.txt
+dnl     nouns.tex:test/nouns.tex nouns-correct.txt:test/nouns-correct.txt
+dnl     part.tex:test/part.tex unterminated.txt:test/unterminated.txt
+dnl     words.tex:test/words.tex words-correct.txt:test/words-correct.txt])
+AC_CONFIG_LINKS([part.tex:test/part.tex])
+AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_CONFIG_SRCDIR([detex.h])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([aux_files])
 AC_CONFIG_MACRO_DIR([m4])
+AC_REQUIRE_AUX_FILE([tap-driver.sh])
 
 AM_INIT_AUTOMAKE([foreign dist-bzip2])
 

--- a/detex.l
+++ b/detex.l
@@ -47,6 +47,7 @@
  *	file.
  */
 
+#include "config.h"
 #include "detex.h"
 
 #ifdef KPATHSEA

--- a/m4/ax_append_flag.m4
+++ b/m4/ax_append_flag.m4
@@ -1,0 +1,71 @@
+# ===========================================================================
+#      https://www.gnu.org/software/autoconf-archive/ax_append_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_APPEND_FLAG(FLAG, [FLAGS-VARIABLE])
+#
+# DESCRIPTION
+#
+#   FLAG is appended to the FLAGS-VARIABLE shell variable, with a space
+#   added in between.
+#
+#   If FLAGS-VARIABLE is not specified, the current language's flags (e.g.
+#   CFLAGS) is used.  FLAGS-VARIABLE is not changed if it already contains
+#   FLAG.  If FLAGS-VARIABLE is unset in the shell, it is set to exactly
+#   FLAG.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 7
+
+AC_DEFUN([AX_APPEND_FLAG],
+[dnl
+AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_SET_IF
+AS_VAR_PUSHDEF([FLAGS], [m4_default($2,_AC_LANG_PREFIX[FLAGS])])
+AS_VAR_SET_IF(FLAGS,[
+  AS_CASE([" AS_VAR_GET(FLAGS) "],
+    [*" $1 "*], [AC_RUN_LOG([: FLAGS already contains $1])],
+    [
+     AS_VAR_APPEND(FLAGS,[" $1"])
+     AC_RUN_LOG([: FLAGS="$FLAGS"])
+    ])
+  ],
+  [
+  AS_VAR_SET(FLAGS,[$1])
+  AC_RUN_LOG([: FLAGS="$FLAGS"])
+  ])
+AS_VAR_POPDEF([FLAGS])dnl
+])dnl AX_APPEND_FLAG

--- a/m4/ax_cflags_warn_all.m4
+++ b/m4/ax_cflags_warn_all.m4
@@ -1,0 +1,122 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_cflags_warn_all.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CFLAGS_WARN_ALL   [(shellvar [,default, [A/NA]])]
+#   AX_CXXFLAGS_WARN_ALL [(shellvar [,default, [A/NA]])]
+#   AX_FCFLAGS_WARN_ALL  [(shellvar [,default, [A/NA]])]
+#
+# DESCRIPTION
+#
+#   Try to find a compiler option that enables most reasonable warnings.
+#
+#   For the GNU compiler it will be -Wall (and -ansi -pedantic) The result
+#   is added to the shellvar being CFLAGS, CXXFLAGS, or FCFLAGS by default.
+#
+#   Currently this macro knows about the GCC, Solaris, Digital Unix, AIX,
+#   HP-UX, IRIX, NEC SX-5 (Super-UX 10), Cray J90 (Unicos 10.0.0.8), and
+#   Intel compilers.  For a given compiler, the Fortran flags are much more
+#   experimental than their C equivalents.
+#
+#    - $1 shell-variable-to-add-to : CFLAGS, CXXFLAGS, or FCFLAGS
+#    - $2 add-value-if-not-found : nothing
+#    - $3 action-if-found : add value to shellvariable
+#    - $4 action-if-not-found : nothing
+#
+#   NOTE: These macros depend on AX_APPEND_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2010 Rhys Ulerich <rhys.ulerich@gmail.com>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 16
+
+AC_DEFUN([AX_FLAGS_WARN_ALL],[dnl
+AS_VAR_PUSHDEF([FLAGS],[_AC_LANG_PREFIX[]FLAGS])dnl
+AS_VAR_PUSHDEF([VAR],[ac_cv_[]_AC_LANG_ABBREV[]flags_warn_all])dnl
+AC_CACHE_CHECK([m4_ifval($1,$1,FLAGS) for maximum warnings],
+VAR,[VAR="no, unknown"
+ac_save_[]FLAGS="$[]FLAGS"
+for ac_arg dnl
+in "-warn all  % -warn all"   dnl Intel
+   "-pedantic  % -Wall"       dnl GCC
+   "-xstrconst % -v"          dnl Solaris C
+   "-std1      % -verbose -w0 -warnprotos" dnl Digital Unix
+   "-qlanglvl=ansi % -qsrcmsg -qinfo=all:noppt:noppc:noobs:nocnd" dnl AIX
+   "-ansi -ansiE % -fullwarn" dnl IRIX
+   "+ESlit     % +w1"         dnl HP-UX C
+   "-Xc        % -pvctl[,]fullmsg" dnl NEC SX-5 (Super-UX 10)
+   "-h conform % -h msglevel 2" dnl Cray C (Unicos)
+   #
+do FLAGS="$ac_save_[]FLAGS "`echo $ac_arg | sed -e 's,%%.*,,' -e 's,%,,'`
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM],
+                     [VAR=`echo $ac_arg | sed -e 's,.*% *,,'` ; break])
+done
+FLAGS="$ac_save_[]FLAGS"
+])
+AS_VAR_POPDEF([FLAGS])dnl
+AX_REQUIRE_DEFINED([AX_APPEND_FLAG])
+case ".$VAR" in
+     .ok|.ok,*) m4_ifvaln($3,$3) ;;
+   .|.no|.no,*) m4_default($4,[m4_ifval($2,[AX_APPEND_FLAG([$2], [$1])])]) ;;
+   *) m4_default($3,[AX_APPEND_FLAG([$VAR], [$1])]) ;;
+esac
+AS_VAR_POPDEF([VAR])dnl
+])dnl AX_FLAGS_WARN_ALL
+dnl  implementation tactics:
+dnl   the for-argument contains a list of options. The first part of
+dnl   these does only exist to detect the compiler - usually it is
+dnl   a global option to enable -ansi or -extrawarnings. All other
+dnl   compilers will fail about it. That was needed since a lot of
+dnl   compilers will give false positives for some option-syntax
+dnl   like -Woption or -Xoption as they think of it is a pass-through
+dnl   to later compile stages or something. The "%" is used as a
+dnl   delimiter. A non-option comment can be given after "%%" marks
+dnl   which will be shown but not added to the respective C/CXXFLAGS.
+
+AC_DEFUN([AX_CFLAGS_WARN_ALL],[dnl
+AC_LANG_PUSH([C])
+AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
+AC_LANG_POP([C])
+])
+
+AC_DEFUN([AX_CXXFLAGS_WARN_ALL],[dnl
+AC_LANG_PUSH([C++])
+AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
+AC_LANG_POP([C++])
+])
+
+AC_DEFUN([AX_FCFLAGS_WARN_ALL],[dnl
+AC_LANG_PUSH([Fortran])
+AX_FLAGS_WARN_ALL([$1], [$2], [$3], [$4])
+AC_LANG_POP([Fortran])
+])

--- a/m4/ax_prog_flex.m4
+++ b/m4/ax_prog_flex.m4
@@ -1,0 +1,59 @@
+# ===========================================================================
+#       https://www.gnu.org/software/autoconf-archive/ax_prog_flex.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_FLEX(ACTION-IF-TRUE,ACTION-IF-FALSE)
+#
+# DESCRIPTION
+#
+#   Check whether flex is the scanner generator. Run ACTION-IF-TRUE if
+#   successful, ACTION-IF-FALSE otherwise
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Francesco Salvestrini <salvestrini@users.sourceforge.net>
+#   Copyright (c) 2010 Diego Elio Petteno` <flameeyes@gmail.com>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 13
+
+AC_DEFUN([AX_PROG_FLEX], [
+  AC_REQUIRE([AM_PROG_LEX])
+  AC_REQUIRE([AC_PROG_EGREP])
+
+  AC_CACHE_CHECK([if flex is the lexer generator],[ax_cv_prog_flex],[
+    AS_IF([$LEX --version 2>/dev/null | $EGREP -qw '^g?flex'],
+      [ax_cv_prog_flex=yes], [ax_cv_prog_flex=no])
+  ])
+  AS_IF([test "$ax_cv_prog_flex" = "yes"],
+    m4_ifnblank([$1], [[$1]]),
+    m4_ifnblank([$2], [[$2]])
+  )
+])

--- a/m4/ax_require_defined.m4
+++ b/m4/ax_require_defined.m4
@@ -1,0 +1,37 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_REQUIRE_DEFINED(MACRO)
+#
+# DESCRIPTION
+#
+#   AX_REQUIRE_DEFINED is a simple helper for making sure other macros have
+#   been defined and thus are available for use.  This avoids random issues
+#   where a macro isn't expanded.  Instead the configure script emits a
+#   non-fatal:
+#
+#     ./configure: line 1673: AX_CFLAGS_WARN_ALL: command not found
+#
+#   It's like AC_REQUIRE except it doesn't expand the required macro.
+#
+#   Here's an example:
+#
+#     AX_REQUIRE_DEFINED([AX_CHECK_LINK_FLAG])
+#
+# LICENSE
+#
+#   Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 2
+
+AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
+  m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])
+])dnl AX_REQUIRE_DEFINED

--- a/test.pl.in
+++ b/test.pl.in
@@ -1,5 +1,8 @@
 #!/usr/bin/perl -w
 
+print "1..10\n";
+my $current_test = 1;
+my $exit_status = 0;
 assert_produces_correct_output('in.tex', 'correct.txt');
 assert_produces_correct_output('in.tex', 'correct.txt', '-l');
 assert_produces_correct_output('noinclude.tex', 'noinclude-correct.txt', '-n');
@@ -12,20 +15,19 @@ run_for_wrong_input("non-existent-file.tex");
 run_for_wrong_input("non-existent-file.txt");
 run_for_wrong_input("test/unterminated.txt");
 
-print "Tests ok\n";
+exit $exit_status;
 
 sub assert_produces_correct_output {
 	my ($input, $correct, $options) = @_;
 	$options ||= '';
 	my $options_desc = $options ? " ($options)" : '';
-	print "Checking correct output is produced for $input->$correct$options_desc\n";
 	execute_cmd("./detex $options @top_srcdir@/test/$input > /tmp/testDelatex.txt");
+	print "Correct output is produced for $input->$correct$options_desc\n";
 
 	my $compared = "@top_srcdir@/test/$correct /tmp/testDelatex.txt";
 	my $diffResult = `diff $compared 2>&1`;
 
 	if ($diffResult ne '') {
-		print "Test failed:\n":
 		if (`which kdiff3`) {
 			system("kdiff3 $compared");
 		} elsif (!$ENV{CI} && `which vimdiff`) {
@@ -33,19 +35,24 @@ sub assert_produces_correct_output {
 		} else {
 			system("diff -u $compared");
 		}
-		exit(11);
 	}
 }
 
 sub run_for_wrong_input {
 	my ($input) = @_;
-	print "Checking response for $input...\n";
 	execute_cmd("./detex @top_srcdir@/$input");
+	print "Response for $input...\n";
 }
 
 sub execute_cmd {
 	my ($cmd) = @_;
-	system(get_cmd($cmd)) or die;
+	if (system(get_cmd($cmd)) == 0) {
+	    print "ok ${current_test} - ";
+	} else {
+	    print "not ok ${current test} - ";
+	    $exit_status = 11;
+	}
+	$current_test = $current_test + 1
 }
 
 sub get_cmd {

--- a/test.pl.in
+++ b/test.pl.in
@@ -28,9 +28,9 @@ sub assert_produces_correct_output {
 	my $diffResult = `diff $compared 2>&1`;
 
 	if ($diffResult ne '') {
-		if (`which kdiff3`) {
+		if (`which kdiff3 2>/dev/null`) {
 			system("kdiff3 $compared");
-		} elsif (!$ENV{CI} && `which vimdiff`) {
+		} elsif (!$ENV{CI} && `which vimdiff 2>/dev/null`) {
 			system("vimdiff $compared");
 		} else {
 			system("diff -u $compared");

--- a/test.pl.in
+++ b/test.pl.in
@@ -18,14 +18,14 @@ sub assert_produces_correct_output {
 	my ($input, $correct, $options) = @_;
 	$options ||= '';
 	my $options_desc = $options ? " ($options)" : '';
-	print "Checking correct output is produced for $input->$correct$options_desc...\n";
-	chdir 'test';
-	execute_cmd("../delatex $options $input > /tmp/testDelatex.txt");
-	my $compared = "$correct /tmp/testDelatex.txt";
+	print "Checking correct output is produced for $input->$correct$options_desc\n";
+	execute_cmd("./detex $options @top_srcdir@/test/$input > /tmp/testDelatex.txt");
+
+	my $compared = "@top_srcdir@/test/$correct /tmp/testDelatex.txt";
 	my $diffResult = `diff $compared 2>&1`;
 
 	if ($diffResult ne '') {
-		print "Test failed:\n";
+		print "Test failed:\n":
 		if (`which kdiff3`) {
 			system("kdiff3 $compared");
 		} elsif (!$ENV{CI} && `which vimdiff`) {
@@ -35,18 +35,17 @@ sub assert_produces_correct_output {
 		}
 		exit(11);
 	}
-	chdir '..'
 }
 
 sub run_for_wrong_input {
 	my ($input) = @_;
 	print "Checking response for $input...\n";
-	execute_cmd("./delatex $input");
+	execute_cmd("./detex @top_srcdir@/$input");
 }
 
 sub execute_cmd {
 	my ($cmd) = @_;
-	system(get_cmd($cmd)) == 0 or die;
+	system(get_cmd($cmd)) or die;
 }
 
 sub get_cmd {

--- a/test/in.tex
+++ b/test/in.tex
@@ -103,7 +103,7 @@ An inline math equation like $a +
 b +
 c$ should not produce an empty line
 
-\input{part}
+\input{test/part}
 \newcounter{equation}
 
 where\addtocounter{equation}{1}\setcounter{equation}{50}


### PR DESCRIPTION
I got mildly annoyed getting my package manager to cooperate with the makefile, so I set up an autotools build system and changed the tests to support TAP.  I have not run valgrind, but I do not think adding a newly generated header with a bunch of ```#define```s would create any memory leaks.

This is one of the cases Autotools is designed for, so it was relatively straightforward.  I missed a few of the names used in ```#ifndef``` clauses.  Should I add those?

I might also be able to simplify the install process in Travis now.   Should I try that as well?