### PR TITLE
Add option to print source information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ SRC	= detex.l
 #
 D_OBJ	= detex.o
 
-VERSION = 2.8.7-SNAPSHOT
+VERSION = 2.8.8-SNAPSHOT
 
 all:	${PROGS}
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ SRC	= detex.l
 #
 D_OBJ	= detex.o
 
-VERSION = 2.8.8-SNAPSHOT
+VERSION = 2.8.7-SNAPSHOT
 
 all:	${PROGS}
 

--- a/detex.1
+++ b/detex.1
@@ -87,6 +87,11 @@ with the deletions mentioned above.  Newline characters are
 preserved where possible
 so that the lines of output match the input as closely as possible.
 .PP
+The 
+.B \-1
+option will prefix each printed line with `filename:linenumber:` indicating
+where that line is coming from in terms of the original (La)TeX document.
+.PP
 The TEXINPUTS environment variable is used to find \\input and \\include
 files.  Like \fITeX\fP, it interprets a leading or trailing `:' as the default
 TEXINPUTS.  It does \fInot\fP support the `//' directory expansion magic sequence.

--- a/detex.h
+++ b/detex.h
@@ -80,7 +80,8 @@
 #define	CHSPACEOPT	's'
 #define	CHTEXOPT	't'
 #define	CHWORDOPT	'w'
-#define CHREPLACE   'r'
-#define CHVERSIONOPT 'v'
+#define CHSRCLOC        '1'
+#define CHREPLACE       'r'
+#define CHVERSIONOPT    'v'
 
 #define	my_ERROR	-1

--- a/detex.h
+++ b/detex.h
@@ -80,8 +80,8 @@
 #define	CHSPACEOPT	's'
 #define	CHTEXOPT	't'
 #define	CHWORDOPT	'w'
-#define CHSRCLOC        '1'
-#define CHREPLACE       'r'
-#define CHVERSIONOPT    'v'
+#define CHSRCLOC	'1'
+#define CHREPLACE	'r'
+#define CHVERSIONOPT	'v'
 
 #define	my_ERROR	-1

--- a/detex.l
+++ b/detex.l
@@ -98,9 +98,9 @@
 #undef ECHO
 
 #define	LaBEGIN		if (fLatex) BEGIN
-#define	IGNORE		Ignore()
-#define INCRLINENO      IncrLineNo()
-#define ECHO            Echo()
+#define	IGNORE      Ignore()
+#define INCRLINENO  IncrLineNo()
+#define ECHO        Echo()
 #define NOUN		if (fSpace && !fWord && !fReplace) putchar(' '); else {if (fReplace) printf("noun");}
 #define VERBNOUN		if (fReplace) printf(" verbs noun"); /* puts a verb and a noun to make grammar checking work */
 #define	SPACE		if (!fWord) putchar(' ')
@@ -599,9 +599,9 @@ main(int cArgs, char *rgsbArgs[])
 			case CHVERSIONOPT:
 			VersionExit();
 			break;
-                    case CHSRCLOC:
-                        fSrcLoc = 1;
-                        break;
+			case CHSRCLOC:
+			fSrcLoc = 1;
+			break;
 		    default:
 			sbBadOpt[0] = *pch;
 			sbBadOpt[1] = '\0';
@@ -699,13 +699,13 @@ yyless(int n)
 void
 LineBreak()
 {
-  if (fWord) return;
-  if (fSrcLoc && fIsColumn0) {
-    printf("%s:%4d: ", fFileNames[csb], fFileLines[csb]);
-    fIsColumn0 = 0;
-  }
-  putchar('\n');
-  fFileLines[csb]++; fIsColumn0=1;
+	if (fWord) return;
+	if (fSrcLoc && fIsColumn0) {
+		printf("%s:%4d: ", fFileNames[csb], fFileLines[csb]);
+		fIsColumn0 = 0;
+	}
+	putchar('\n');
+	fFileLines[csb]++; fIsColumn0=1;
 }
 
 /******
@@ -716,11 +716,11 @@ LineBreak()
 void
 Echo()
 {
-  if (fSrcLoc && fIsColumn0) {
-    printf("%s:%4d: ", fFileNames[csb], fFileLines[csb]+1);
-    fIsColumn0 = 0;
-  }
-  fprintf(yyout, "%s", yytext);
+	if (fSrcLoc && fIsColumn0) {
+		printf("%s:%4d: ", fFileNames[csb], fFileLines[csb]);
+		fIsColumn0 = 0;
+	}
+	fprintf(yyout, "%s", yytext);
 }
 
 /******
@@ -731,11 +731,11 @@ Echo()
 void
 IncrLineNo()
 {
-  for (char* c=yytext; *c != '\0'; c++) {
-    if (*c == '\n') {
-      fFileLines[csb]++; fIsColumn0=1;
-    }
-  }
+	for (char* c=yytext; *c != '\0'; c++) {
+		if (*c == '\n') {
+			fFileLines[csb]++; fIsColumn0=1;
+		}
+	}
 }
 
 /******
@@ -746,8 +746,8 @@ IncrLineNo()
 void 
 Ignore()
 {
-  IncrLineNo();
-  if (fSpace && !fWord) putchar(' ');
+	IncrLineNo();
+	if (fSpace && !fWord) putchar(' ');
 }
 
 /******
@@ -821,7 +821,7 @@ InputFile(char *sbFile)
 	} 
 #ifdef FLEX_SCANNER
         rgsb[csb++]     = YY_CURRENT_BUFFER;
-        fFileLines[csb] = 0;
+        fFileLines[csb] = 1;
         stracpy(&fFileNames[csb], sbFile);
         yy_switch_to_buffer(yy_create_buffer( yyin, YY_BUF_SIZE ) );
 #endif /* FLEX_SCANNER */
@@ -849,7 +849,7 @@ IncludeFile(char *sbFile)
 	}
 #ifdef FLEX_SCANNER
         rgsb[csb++]     = YY_CURRENT_BUFFER;
-        fFileLines[csb] = 0;
+        fFileLines[csb] = 1;
         stracpy(&fFileNames[csb], sbFile);
         yy_switch_to_buffer(yy_create_buffer( yyin, YY_BUF_SIZE ) );
 #endif /* FLEX_SCANNER */

--- a/detex.l
+++ b/detex.l
@@ -1088,7 +1088,7 @@ ErrorExit(const char *sb1)
 void
 UsageExit(void)
 {
-	(void)printf("\n%s [ -clnrstw ] [ -e environment-list ] [ filename[.tex] ... ]\n",
+	(void)printf("\n%s [ -clnrstw1 ] [ -e environment-list ] [ filename[.tex] ... ]\n",
 		sbProgName);
 	puts("  -c  echo LaTeX \\cite, \\ref, and \\pageref values\n  \
 -e  <env-list> list of LaTeX environments to ignore\n  \

--- a/detex.l
+++ b/detex.l
@@ -41,7 +41,7 @@
 
 
 /*
- * detex [-e environment-list] [-c] [-l] [-n] [-s] [-t] [-w] [file[.tex] ]
+ * detex [-e environment-list] [-c] [-l] [-n] [-s] [-t] [-w] [-1] [file[.tex] ]
  *
  *	This program is used to remove TeX or LaTeX constructs from a text
  *	file.
@@ -95,13 +95,16 @@
 
 %{
 #undef IGNORE
+#undef ECHO
 
 #define	LaBEGIN		if (fLatex) BEGIN
-#define	IGNORE		if (fSpace && !fWord) putchar(' ')
+#define	IGNORE		Ignore()
+#define INCRLINENO      IncrLineNo()
+#define ECHO            Echo()
 #define NOUN		if (fSpace && !fWord && !fReplace) putchar(' '); else {if (fReplace) printf("noun");}
 #define VERBNOUN		if (fReplace) printf(" verbs noun"); /* puts a verb and a noun to make grammar checking work */
 #define	SPACE		if (!fWord) putchar(' ')
-#define	NEWLINE		if (!fWord) putchar('\n')
+#define	NEWLINE		LineBreak()
 #define	LATEX		fLatex=!fForcetex
 #define KILLARGS(x)	cArgs=x; LaBEGIN LaMacro
 #define STRIPARGS(x)	cArgs=x; LaBEGIN LaMacro2
@@ -109,6 +112,10 @@
 
 #define NO_MALLOC_DECL
 
+void LineBreak();
+void Ignore();
+void IncrLineNo();
+void Echo();
 void AddInclude(char *sbFile);
 void ErrorExit(const char *sb1);
 void UsageExit(void);
@@ -158,6 +165,7 @@ int	fFollow = 1;			/* flag to follow input/include */
 int	fCite = 0;			/* flag to echo \cite and \ref args */
 int	fSpace = 0;			/* flag to replace \cs with space */
 int	fForcetex = 0;			/* flag to inhibit latex mode */
+int	fSrcLoc = 0;			/* flag to display source location of original file */
 int fShowPictures = 0;  /* flag to show picture names */
 int fReplace = 0;  /* flag to replace envirnments with "noun" */
 
@@ -169,7 +177,10 @@ int footnoteLevel = -100;
  * otherwise output contains imported files in reverse order.  Weird, but
  * true.
  */
-YY_BUFFER_STATE rgsb[NOFILE + 1]; /* flex context stack */
+YY_BUFFER_STATE rgsb[NOFILE + 1];        /* flex context stack */
+char*           fFileNames[NOFILE + 1];  /* names of the buffers in context stack */
+int             fFileLines[NOFILE + 1];  /* line number in each of the context files */
+int             fIsColumn0 = 1;          /* Are we at the begining of a line? */
 int             csb = 0;		 /* depth of flex context stack */
 #endif /* FLEX_SCANNER */
 
@@ -195,7 +206,7 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 %start LaBreak LaPicture
 
 %%
-<Normal>"%".*		/* ignore comments */	;
+<Normal>"%".*		/* ignore comments */	{INCRLINENO;}
 
 <Normal>"\\begin"{S}"{"{S}"document"{S}"}""\n"*	{LATEX; IGNORE;}
 
@@ -243,11 +254,11 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 						    IGNORE;
 						}
 	/*<LaBegin>"\n"					NEWLINE;*/
-<LaBegin>.					;
+<LaBegin>.					{INCRLINENO;}
 
 <LaEnv>"\\end"  /* absorb some environments */	{LaBEGIN LaEnd; IGNORE;}
 <LaEnv>"\n"+					;/*NEWLINE;*/
-<LaEnv>.					;
+<LaEnv>.					{INCRLINENO;}
 
 <LaEnd>{W}		 /* end environment */	{   if (EndEnv(yytext))
 							BEGIN Normal;
@@ -255,7 +266,7 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 						}
 <LaEnd>"}"					{BEGIN LaEnv; IGNORE;}
 	/*<LaEnd>"\n"					NEWLINE;*/
-<LaEnd>.					;
+<LaEnd>.					{INCRLINENO;}
 
 <Normal>"\\kern"{HD}				;
 <Normal>"\\vskip"{VG}				;
@@ -285,7 +296,7 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 
 <LaPicture>"{"					;
 <LaPicture>[^{}]+				{ if(fShowPictures) { printf("<Picture %s>", yytext); } }
-<LaPicture>"\}"{S}"\n"+					BEGIN Normal;
+<LaPicture>"\}"{S}"\n"+				{ BEGIN Normal; INCRLINENO; }
 <LaPicture>"\}"					BEGIN Normal;
 
 <Normal>"\\definecolor"				{ KILLARGS(3); }
@@ -459,13 +470,13 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 							ECHO;
 						}
 <Normal>[0-9]+					if (!fWord) ECHO;
-<Normal>.					if (!fWord) ECHO;
-<Normal>"\n"					if (!fWord) NEWLINE;
+<Normal>.					{ INCRLINENO; if (!fWord) ECHO; }
+<Normal>"\n"					{ if (!fWord) NEWLINE; }
 <Normal>("\t")+					if (!fWord) putchar('\t');
 
 <LaMacro>"\["					{ BEGIN LaOptArg; }
 <LaMacro>"{"					{ cOpenBrace++; }
-<LaMacro>"}""\n"{0,1}					{   cOpenBrace--;
+<LaMacro>"}""\n"{0,1}				{   cOpenBrace--; INCRLINENO;
 						    if (cOpenBrace == 0)
 						    {
 							if (--cArgs==0)
@@ -494,6 +505,15 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 %%
 
 /******
+** stracpy -- String Allocate and Copy;
+******/
+
+void stracpy(char** dest, char* src) {
+  *dest = SafeMalloc(strlen(src), "Can't allocate mem");
+  strcpy(*dest , src);
+}
+
+/******
 ** main --
 **	Set sbProgName to the base of arg 0.
 **	Set the input paths.
@@ -505,6 +525,7 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 **		-s		replace control sequences with space
 **		-t		force tex mode
 **		-w		word only output
+**              -1              output some location information
 **	Set the list of LaTeX environments to ignore.
 **	Process each input file.
 **	If no input files are specified on the command line, process stdin.
@@ -578,6 +599,9 @@ main(int cArgs, char *rgsbArgs[])
 			case CHVERSIONOPT:
 			VersionExit();
 			break;
+                    case CHSRCLOC:
+                        fSrcLoc = 1;
+                        break;
 		    default:
 			sbBadOpt[0] = *pch;
 			sbBadOpt[1] = '\0';
@@ -599,6 +623,8 @@ main(int cArgs, char *rgsbArgs[])
 		Warning("can't open file", rgsbArgs[iArgs]);
 		continue;;
 	    }
+            fFileNames[csb] = rgsbArgs[iArgs];
+            fFileLines[csb] = 1;
 	    BEGIN Normal;
 	    (void)yylex();
 	}
@@ -666,6 +692,65 @@ yyless(int n)
 #endif
 
 /******
+** LineBreak -- choses the proper way to break a line. If '-1' option is
+**      enabled we also want to output some source location information.
+******/
+
+void
+LineBreak()
+{
+  if (fWord) return;
+  if (fSrcLoc && fIsColumn0) {
+    printf("%s:%4d: ", fFileNames[csb], fFileLines[csb]);
+    fIsColumn0 = 0;
+  }
+  putchar('\n');
+  fFileLines[csb]++; fIsColumn0=1;
+}
+
+/******
+** Echo -- If we are at column 0 and have specified '-1'; output 
+**      the source location information.
+******/
+
+void
+Echo()
+{
+  if (fSrcLoc && fIsColumn0) {
+    printf("%s:%4d: ", fFileNames[csb], fFileLines[csb]+1);
+    fIsColumn0 = 0;
+  }
+  fprintf(yyout, "%s", yytext);
+}
+
+/******
+** IncrLineNo -- Increase the correct linenumber counter and
+**      reset the the 'fIsColumn0' to true.
+******/
+
+void
+IncrLineNo()
+{
+  for (char* c=yytext; *c != '\0'; c++) {
+    if (*c == '\n') {
+      fFileLines[csb]++; fIsColumn0=1;
+    }
+  }
+}
+
+/******
+** Ignore -- Since we might need to track source location information we
+**    cannot just ignore text. We must at least increase the linenumber counter.
+******/
+
+void 
+Ignore()
+{
+  IncrLineNo();
+  if (fSpace && !fWord) putchar(' ');
+}
+
+/******
 ** SetEnvIgnore -- sets rgsbEnvIgnore to the values indicated by the
 **	sbEnvList.
 ******/
@@ -720,6 +805,7 @@ EndEnv(const char *sbEnv)
 **	the sbFile is ignored.
 ******/
 
+
 void
 InputFile(char *sbFile)
 {
@@ -734,7 +820,9 @@ InputFile(char *sbFile)
             return;
 	} 
 #ifdef FLEX_SCANNER
-        rgsb[csb++] = YY_CURRENT_BUFFER;
+        rgsb[csb++]     = YY_CURRENT_BUFFER;
+        fFileLines[csb] = 0;
+        stracpy(&fFileNames[csb], sbFile);
         yy_switch_to_buffer(yy_create_buffer( yyin, YY_BUF_SIZE ) );
 #endif /* FLEX_SCANNER */
 }
@@ -760,7 +848,9 @@ IncludeFile(char *sbFile)
             return;
 	}
 #ifdef FLEX_SCANNER
-        rgsb[csb++] = YY_CURRENT_BUFFER;
+        rgsb[csb++]     = YY_CURRENT_BUFFER;
+        fFileLines[csb] = 0;
+        stracpy(&fFileNames[csb], sbFile);
         yy_switch_to_buffer(yy_create_buffer( yyin, YY_BUF_SIZE ) );
 #endif /* FLEX_SCANNER */
 }
@@ -1008,6 +1098,7 @@ UsageExit(void)
 -s  replace control sequences with space\n  \
 -t  force tex mode\n  \
 -w  word only output\n  \
+-1  outputs the original file name and line number in the beginning of each line\n  \
 -v  show program version and exit");
 	exit(0);
 }

--- a/detex.l
+++ b/detex.l
@@ -98,9 +98,9 @@
 #undef ECHO
 
 #define	LaBEGIN		if (fLatex) BEGIN
-#define	IGNORE      Ignore()
-#define INCRLINENO  IncrLineNo()
-#define ECHO        Echo()
+#define	IGNORE		Ignore()
+#define INCRLINENO	IncrLineNo()
+#define ECHO		Echo()
 #define NOUN		if (fSpace && !fWord && !fReplace) putchar(' '); else {if (fReplace) printf("noun");}
 #define VERBNOUN		if (fReplace) printf(" verbs noun"); /* puts a verb and a noun to make grammar checking work */
 #define	SPACE		if (!fWord) putchar(' ')
@@ -166,8 +166,8 @@ int	fCite = 0;			/* flag to echo \cite and \ref args */
 int	fSpace = 0;			/* flag to replace \cs with space */
 int	fForcetex = 0;			/* flag to inhibit latex mode */
 int	fSrcLoc = 0;			/* flag to display source location of original file */
-int fShowPictures = 0;  /* flag to show picture names */
-int fReplace = 0;  /* flag to replace envirnments with "noun" */
+int fShowPictures = 0;	/* flag to show picture names */
+int fReplace = 0;		/* flag to replace envirnments with "noun" */
 
 int currBracesLevel = 0;
 int footnoteLevel = -100;
@@ -177,11 +177,11 @@ int footnoteLevel = -100;
  * otherwise output contains imported files in reverse order.  Weird, but
  * true.
  */
-YY_BUFFER_STATE rgsb[NOFILE + 1];        /* flex context stack */
-char*           fFileNames[NOFILE + 1];  /* names of the buffers in context stack */
-int             fFileLines[NOFILE + 1];  /* line number in each of the context files */
-int             fIsColumn0 = 1;          /* Are we at the begining of a line? */
-int             csb = 0;		 /* depth of flex context stack */
+YY_BUFFER_STATE rgsb[NOFILE + 1];		/* flex context stack */
+char*			fFileNames[NOFILE + 1];	/* names of the buffers in context stack */
+int				fFileLines[NOFILE + 1];	/* line number in each of the context files */
+int				fIsColumn0 = 1;			/* Are we at the begining of a line? */
+int				csb = 0;				/* depth of flex context stack */
 #endif /* FLEX_SCANNER */
 
 %}
@@ -505,15 +505,6 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 %%
 
 /******
-** stracpy -- String Allocate and Copy;
-******/
-
-void stracpy(char** dest, char* src) {
-  *dest = SafeMalloc(strlen(src), "Can't allocate mem");
-  strcpy(*dest , src);
-}
-
-/******
 ** main --
 **	Set sbProgName to the base of arg 0.
 **	Set the input paths.
@@ -623,8 +614,8 @@ main(int cArgs, char *rgsbArgs[])
 		Warning("can't open file", rgsbArgs[iArgs]);
 		continue;;
 	    }
-            fFileNames[csb] = rgsbArgs[iArgs];
-            fFileLines[csb] = 1;
+		fFileNames[csb] = rgsbArgs[iArgs];
+		fFileLines[csb] = 1;
 	    BEGIN Normal;
 	    (void)yylex();
 	}
@@ -663,6 +654,7 @@ yywrap(void)
 #ifdef FLEX_SCANNER
         /* Pop context state */
 	if (csb > 0) {
+		free(fFileNames[csb]);
 		yy_delete_buffer( YY_CURRENT_BUFFER );
 		yy_switch_to_buffer( rgsb[--csb] );
 	}
@@ -692,40 +684,49 @@ yyless(int n)
 #endif
 
 /******
+** PrintPrefix -- In case fSrcLoc is 1 and we are about to
+**	print the first column of a line, we want to output the location of
+**	that line in the original LaTeX document it came from.
+******/
+
+void
+PrintPrefix()
+{
+	if (fSrcLoc && fIsColumn0) {
+		printf("%s:%d: ", fFileNames[csb], fFileLines[csb]);
+		fIsColumn0 = 0;
+	}
+}
+
+/******
 ** LineBreak -- choses the proper way to break a line. If '-1' option is
-**      enabled we also want to output some source location information.
+**	enabled we also want to output some source location information.
 ******/
 
 void
 LineBreak()
 {
 	if (fWord) return;
-	if (fSrcLoc && fIsColumn0) {
-		printf("%s:%4d: ", fFileNames[csb], fFileLines[csb]);
-		fIsColumn0 = 0;
-	}
+	PrintPrefix();
 	putchar('\n');
 	fFileLines[csb]++; fIsColumn0=1;
 }
 
 /******
 ** Echo -- If we are at column 0 and have specified '-1'; output 
-**      the source location information.
+**	the source location information.
 ******/
 
 void
 Echo()
 {
-	if (fSrcLoc && fIsColumn0) {
-		printf("%s:%4d: ", fFileNames[csb], fFileLines[csb]);
-		fIsColumn0 = 0;
-	}
+	PrintPrefix();
 	fprintf(yyout, "%s", yytext);
 }
 
 /******
 ** IncrLineNo -- Increase the correct linenumber counter and
-**      reset the the 'fIsColumn0' to true.
+**	reset the the 'fIsColumn0' to true.
 ******/
 
 void
@@ -740,7 +741,7 @@ IncrLineNo()
 
 /******
 ** Ignore -- Since we might need to track source location information we
-**    cannot just ignore text. We must at least increase the linenumber counter.
+**	cannot just ignore text. We must at least increase the linenumber counter.
 ******/
 
 void 
@@ -820,10 +821,10 @@ InputFile(char *sbFile)
             return;
 	} 
 #ifdef FLEX_SCANNER
-        rgsb[csb++]     = YY_CURRENT_BUFFER;
-        fFileLines[csb] = 1;
-        stracpy(&fFileNames[csb], sbFile);
-        yy_switch_to_buffer(yy_create_buffer( yyin, YY_BUF_SIZE ) );
+	rgsb[csb++]     = YY_CURRENT_BUFFER;
+	fFileLines[csb] = 1;
+	fFileNames[csb] = strdup(sbFile);
+	yy_switch_to_buffer(yy_create_buffer( yyin, YY_BUF_SIZE ) );
 #endif /* FLEX_SCANNER */
 }
 
@@ -848,10 +849,10 @@ IncludeFile(char *sbFile)
             return;
 	}
 #ifdef FLEX_SCANNER
-        rgsb[csb++]     = YY_CURRENT_BUFFER;
-        fFileLines[csb] = 1;
-        stracpy(&fFileNames[csb], sbFile);
-        yy_switch_to_buffer(yy_create_buffer( yyin, YY_BUF_SIZE ) );
+	rgsb[csb++]     = YY_CURRENT_BUFFER;
+	fFileLines[csb] = 1;
+	fFileNames[csb] = strdup(sbFile);
+	yy_switch_to_buffer(yy_create_buffer( yyin, YY_BUF_SIZE ) );
 #endif /* FLEX_SCANNER */
 }
 

--- a/test.pl
+++ b/test.pl
@@ -6,6 +6,7 @@ assert_produces_correct_output('noinclude.tex', 'noinclude-correct.txt', '-n');
 assert_produces_correct_output('words.tex', 'words-correct.txt', '-w');
 assert_produces_correct_output('words.tex', 'words-correct.txt', '-w -l');
 assert_produces_correct_output('nouns.tex', 'nouns-correct.txt', '-r');
+assert_produces_correct_output('with-srcloc.tex', 'with-srcloc-correct.txt', '-1');
 
 run_for_wrong_input("non-existent-file");
 run_for_wrong_input("non-existent-file.tex");

--- a/test/part-2.tex
+++ b/test/part-2.tex
@@ -1,0 +1,4 @@
+Some larger text to be included.
+
+This is line 3.
+And this is line 4.

--- a/test/with-srcloc-correct.txt
+++ b/test/with-srcloc-correct.txt
@@ -1,0 +1,16 @@
+with-srcloc.tex:   2: 
+with-srcloc.tex:   4: 
+with-srcloc.tex:   7: Some text on line 7
+with-srcloc.tex:   8: 
+with-srcloc.tex:   9: 
+with-srcloc.tex:  10: Some figure on line 10
+with-srcloc.tex:  12: 
+part:   1: Text to include.
+with-srcloc.tex:  13: 
+with-srcloc.tex:  14: 
+part-2:   1: Some larger text to be included.
+part-2:   2: 
+part-2:   3: This is line 3.
+part-2:   4: And this is line 4.
+with-srcloc.tex:  15: 
+with-srcloc.tex:  16: 

--- a/test/with-srcloc-correct.txt
+++ b/test/with-srcloc-correct.txt
@@ -1,16 +1,16 @@
-with-srcloc.tex:   2: 
-with-srcloc.tex:   4: 
-with-srcloc.tex:   7: Some text on line 7
-with-srcloc.tex:   8: 
-with-srcloc.tex:   9: 
-with-srcloc.tex:  10: Some figure on line 10
-with-srcloc.tex:  12: 
-part:   1: Text to include.
-with-srcloc.tex:  13: 
-with-srcloc.tex:  14: 
-part-2:   1: Some larger text to be included.
-part-2:   2: 
-part-2:   3: This is line 3.
-part-2:   4: And this is line 4.
-with-srcloc.tex:  15: 
-with-srcloc.tex:  16: 
+with-srcloc.tex:2: 
+with-srcloc.tex:4: 
+with-srcloc.tex:7: Some text on line 7
+with-srcloc.tex:8: 
+with-srcloc.tex:9: 
+with-srcloc.tex:10: Some figure on line 10
+with-srcloc.tex:12: 
+part:1: Text to include.
+with-srcloc.tex:13: 
+with-srcloc.tex:14: 
+part-2:1: Some larger text to be included.
+part-2:2: 
+part-2:3: This is line 3.
+part-2:4: And this is line 4.
+with-srcloc.tex:15: 
+with-srcloc.tex:16: 

--- a/test/with-srcloc.tex
+++ b/test/with-srcloc.tex
@@ -1,0 +1,17 @@
+\documentclass{testing}
+
+\usepackage{whatever}
+
+\begin{document}
+
+Some text on line 7
+
+\begin{figure}
+Some figure on line 10
+\end{figure}
+
+\input{part}
+
+\include{part-2}
+
+\end{document}


### PR DESCRIPTION
I wanted to use `detex` to feed text to `diction`. The problem is that diction will output a number of style and grammar suggestions with on the _detex-fied_ file. If I could see the line number of the _original_ file in the diction suggestions it would be much easier to combine these tools.

For that purpose, I added the `-1` option to do exactly that. I have no idea what to call it and I'm happy to change if necessary.

I have tried to make it play well with `\input` and `\include` as much as possible but welcome any feedback.