### PR TITLE
Support escaped percent sign

### DIFF
--- a/detex.l
+++ b/detex.l
@@ -423,6 +423,7 @@ VERBSYMBOL	=|\\leq|\\geq|\\in|>|<|\\subseteq|\subseteq|\\subset|\\supset|\\sim|\
 
 	/* escaping commands */
 <Normal>"\\slash"			putchar('/');
+<Normal>"\\%"				putchar('%');
 
 <Normal>\\(aa|AA|ae|AE|oe|OE|ss)[ \t]*[ \t\n}] /* handle ligatures */	{(void)printf("%.2s", yytext+1);}
 <Normal>\\[OoijLl][ \t]*[ \t\n}]		{(void)printf("%.1s", yytext+1);}

--- a/test.pl
+++ b/test.pl
@@ -7,6 +7,7 @@ assert_produces_correct_output('words.tex', 'words-correct.txt', '-w');
 assert_produces_correct_output('words.tex', 'words-correct.txt', '-w -l');
 assert_produces_correct_output('nouns.tex', 'nouns-correct.txt', '-r');
 assert_produces_correct_output('with-srcloc.tex', 'with-srcloc-correct.txt', '-1');
+assert_produces_correct_output('comments.tex', 'comments-correct.txt');
 
 run_for_wrong_input("non-existent-file");
 run_for_wrong_input("non-existent-file.tex");

--- a/test/comments-correct.txt
+++ b/test/comments-correct.txt
@@ -1,0 +1,2 @@
+
+This 100% has a percent sign and will be included.

--- a/test/comments.tex
+++ b/test/comments.tex
@@ -1,0 +1,5 @@
+\documentclass[draft]{book}
+\begin{document}
+%This is a comment and will not be included.
+This 100\% has a percent sign and will be included.
+\end{document}


### PR DESCRIPTION
I ran into this issue today where `\%` was being ignoring and not printing a percent sign back.

I've got a basic fix here but I'm not entirely sure if this is a full fix. I've added a test file for this behaviour as well as showing that comments are still removed as expected.

Running `make test` shows that all tests still pass. Running `./test.pl --valgrind` shows that all tests pass without leaking memory. However I can't seem to get `./valgrind.sh` to work, for some reason it fails to compile but that is not a result of the code I've added.