### PR TITLE
Update packages required for Debian system compilation

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -4,7 +4,7 @@ To build the program, you need:
 * 'lex' implementation (for example, flex)
 
 Debian/Ubuntu users can install those by executing:
-   sudo apt-get install make gcc flex
+   sudo apt-get install make gcc flex libfl-dev
 
 To compile the program, simply execute
    make


### PR DESCRIPTION
I found I needed to install the dev library on Ubuntu 20.04 (focal) to get the compilation on v2.8.9 to work.

It looks like this library provides `libfl.so` that is required to compile.

The `flex` package used to depend on `libfl-dev`, per [this](https://askubuntu.com/questions/289547/where-are-flex-libraries-located) but now only recommends it:
```
apt show flex

Package: flex
Version: 2.6.4-6.2
Priority: optional
Section: devel
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Manoj Srivastava <srivasta@debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 975 kB
Pre-Depends: debconf | debconf-2.0
Depends: libc6 (>= 2.26), m4
Recommends: gcc | c-compiler, libfl-dev
Suggests: bison, build-essential, flex-doc
<snipped>
```

An alternative workaround would be to suggest `flex-old`, for v2.5.4a flex and older.